### PR TITLE
fix usage of VertexStream and adjust data representation.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub use crate::shadow::*;
 pub use crate::simplify::*;
 pub use crate::stripify::*;
 pub use crate::utilities::*;
+use std::marker::PhantomData;
 
 /// Vertex attribute stream, similar to glVertexPointer
 ///
@@ -32,6 +33,39 @@ pub use crate::utilities::*;
 /// the spacing between successive elements.
 #[derive(Debug, Copy, Clone)]
 pub struct VertexStream<'a> {
-    pub data: &'a [u8],
+    /// Pointer to buffer which contains vertex data.
+    pub data: *const u8,
+    /// Space between vertices inside the buffer (in bytes).
     pub stride: usize,
+    /// The size in bytes of the vertex attribute this Stream is representing.
+    pub size: usize,
+
+    _marker: PhantomData<&'a ()>,
+}
+
+impl<'a> VertexStream<'a> {
+    /// Create a `VertexStream` for a buffer consisting only of elements of type `T`.
+    pub fn new<T>(ptr: *const T) -> VertexStream<'a> {
+        Self::new_with_stride::<T, T>(ptr, std::mem::size_of::<T>())
+    }
+
+    /// Create a `VertexStream` for a buffer that contains elements of type `VertexType`.
+    ///
+    /// The buffer pointed to by `ptr` starts with one value of `T`, the next value of T
+    /// is `*(ptr + stride)`.
+    ///
+    /// (The `VertexType` does not need to be a concrete type,
+    /// it is only used here to avoid casts on the caller side).
+    pub fn new_with_stride<T, VertexType>(
+        ptr: *const VertexType,
+        stride: usize,
+    ) -> VertexStream<'a> {
+        VertexStream {
+            data: ptr as *const u8,
+            stride,
+            size: std::mem::size_of::<T>(),
+
+            _marker: PhantomData,
+        }
+    }
 }

--- a/src/remap.rs
+++ b/src/remap.rs
@@ -49,8 +49,8 @@ pub fn generate_vertex_remap_multi<T>(
     let streams: Vec<ffi::meshopt_Stream> = streams
         .iter()
         .map(|stream| ffi::meshopt_Stream {
-            data: stream.data.as_ptr() as *const ::std::ffi::c_void,
-            size: stream.data.len(),
+            data: stream.data as *const ::std::ffi::c_void,
+            size: stream.size,
             stride: stream.stride,
         })
         .collect();

--- a/src/shadow.rs
+++ b/src/shadow.rs
@@ -43,8 +43,8 @@ pub fn generate_shadow_indices_multi(
     let streams: Vec<ffi::meshopt_Stream> = streams
         .iter()
         .map(|stream| ffi::meshopt_Stream {
-            data: stream.data.as_ptr() as *const ::std::ffi::c_void,
-            size: stream.data.len(),
+            data: stream.data as *const ::std::ffi::c_void,
+            size: stream.size,
             stride: stream.stride,
         })
         .collect();


### PR DESCRIPTION
Before this change, a `VertexStream` contained a slice of `u8` data
as well as a stride.

The size of the vertex attribute was wrongly assumed to be data.len()
which would lead to assertion violations in the C code.

The structure of `VertexStream` has been changed to contain a poitner to
the buffer data, the size of the vertex attribute the `VertexStream`
describes and a stride.

Additionally, new methods have been added to the `VertexStream` type to
ease its creation.