### PR TITLE
upgrade memoffset

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ miniz_oxide = "0.2.2"
 rand = "0.7.0"
 libc = "0.2.59"
 structopt = "0.2"
-memoffset = "0.4.0"
+memoffset = "0.5.0"
 
 [dev-dependencies.gltf]
 version = "0.12.0"


### PR DESCRIPTION
Bump memoffset to 0.5.0.

Version 0.4.0 had a [critical bug](https://github.com/RustSec/advisory-db/pull/124).