### PR TITLE
build.rs: added missing allocator.cpp to source_files

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -11,6 +11,7 @@ fn main() {
 
     // Add the files we build
     let source_files = [
+        "vendor/src/allocator.cpp",
         "vendor/src/clusterizer.cpp",
         "vendor/src/indexcodec.cpp",
         "vendor/src/indexgenerator.cpp",


### PR DESCRIPTION
`allocator.cpp` was missing in the source files list making it impossible to use `meshopt_setAllocator`.