### PR TITLE
Include the include_wasm header files in the uploaded crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ include = [
     "vendor/src/vertexcodec.cpp",
     "vendor/src/vfetchanalyzer.cpp",
     "vendor/src/vfetchoptimizer.cpp",
+    "include_wasm32/*.h",
 ]
 edition = "2018"
 


### PR DESCRIPTION
I totally forgot to add those in my previous PR, since I was using the patch mechanism, which uses the Git files and not the crate manifest to get the proper files.