### PR TITLE
Add `result_error` to `simplify` function

### DIFF
--- a/src/simplify.rs
+++ b/src/simplify.rs
@@ -13,6 +13,7 @@ pub fn simplify(
     vertices: &VertexDataAdapter<'_>,
     target_count: usize,
     target_error: f32,
+    result_error: Option<&mut f32>,
 ) -> Vec<u32> {
     let vertex_data = vertices.reader.get_ref();
     let vertex_data = vertex_data.as_ptr().cast::<u8>();
@@ -28,7 +29,7 @@ pub fn simplify(
             vertices.vertex_stride,
             target_count,
             target_error,
-            std::ptr::null_mut(),
+            result_error.map_or_else(std::ptr::null_mut, |v| v as *mut _),
         )
     };
     result.resize(index_count, 0u32);
@@ -47,6 +48,7 @@ pub fn simplify_decoder<T: DecodePosition>(
     vertices: &[T],
     target_count: usize,
     target_error: f32,
+    result_error: Option<&mut f32>,
 ) -> Vec<u32> {
     let positions = vertices
         .iter()
@@ -63,7 +65,7 @@ pub fn simplify_decoder<T: DecodePosition>(
             mem::size_of::<f32>() * 3,
             target_count,
             target_error,
-            std::ptr::null_mut(),
+            result_error.map_or_else(std::ptr::null_mut, |v| v as *mut _),
         )
     };
     result.resize(index_count, 0u32);
@@ -82,6 +84,7 @@ pub fn simplify_sloppy(
     vertices: &VertexDataAdapter<'_>,
     target_count: usize,
     target_error: f32,
+    result_error: Option<&mut f32>,
 ) -> Vec<u32> {
     let vertex_data = vertices.reader.get_ref();
     let vertex_data = vertex_data.as_ptr().cast::<u8>();
@@ -97,7 +100,7 @@ pub fn simplify_sloppy(
             vertices.vertex_stride,
             target_count,
             target_error,
-            std::ptr::null_mut(),
+            result_error.map_or_else(std::ptr::null_mut, |v| v as *mut _),
         )
     };
     result.resize(index_count, 0u32);
@@ -116,6 +119,7 @@ pub fn simplify_sloppy_decoder<T: DecodePosition>(
     vertices: &[T],
     target_count: usize,
     target_error: f32,
+    result_error: Option<&mut f32>,
 ) -> Vec<u32> {
     let positions = vertices
         .iter()
@@ -132,7 +136,7 @@ pub fn simplify_sloppy_decoder<T: DecodePosition>(
             mem::size_of::<f32>() * 3,
             target_count,
             target_error,
-            std::ptr::null_mut(),
+            result_error.map_or_else(std::ptr::null_mut, |v| v as *mut _),
         )
     };
     result.resize(index_count, 0u32);


### PR DESCRIPTION
The `meshopt_simplify` function has an optional `result_error` out param that `meshopt-rs` ignores. I added them as an `Option<&mut f32>`, I know this is a breaking change, but we should follow the original API as much as we can in my opinion.