### PR TITLE
Update to latest meshoptimizer, regenerate bindings, add vertex lock API

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -122,8 +122,7 @@ pub struct EncodeObject {
 }
 
 pub fn calc_pos_offset_and_scale(positions: &[f32]) -> ([f32; 3], f32) {
-    use std::f32::MAX;
-
+    const MAX: f32 = f32::MAX;
     let pos_offset = positions
         .chunks(3)
         .fold([MAX, MAX, MAX], |result, position| {
@@ -151,7 +150,7 @@ pub fn calc_pos_offset_and_scale_inverse(positions: &[f32]) -> ([f32; 3], f32) {
 }
 
 pub fn calc_uv_offset_and_scale(coords: &[f32]) -> ([f32; 2], [f32; 2]) {
-    use std::f32::MAX;
+    const MAX: f32 = f32::MAX;
 
     let uv_offset = coords.chunks(2).fold([MAX, MAX], |result, coord| {
         [result[0].min(coord[0]), result[1].min(coord[1])]

--- a/src/simplify.rs
+++ b/src/simplify.rs
@@ -89,6 +89,91 @@ pub fn simplify_decoder<T: DecodePosition>(
     result
 }
 
+/// Reduces the number of triangles in the mesh, attempting to preserve mesh
+/// appearance as much as possible, while respecting the given vertex locks
+///
+/// The resulting index buffer references vertices from the original vertex buffer.
+///
+/// If the original vertex data isn't required, creating a compact vertex buffer
+/// using `optimize_vertex_fetch` is recommended.
+pub fn simplify_with_locks(
+    indices: &[u32],
+    vertices: &VertexDataAdapter<'_>,
+    vertex_lock: &[bool],
+    target_count: usize,
+    target_error: f32,
+    options: SimplifyOptions,
+) -> Vec<u32> {
+    let vertex_data = vertices.reader.get_ref();
+    let vertex_data = vertex_data.as_ptr().cast::<u8>();
+    let positions = unsafe { vertex_data.add(vertices.position_offset) };
+    let mut result: Vec<u32> = vec![0; indices.len()];
+    let index_count = unsafe {
+        ffi::meshopt_simplifyWithAttributes(
+            result.as_mut_ptr().cast(),
+            indices.as_ptr().cast(),
+            indices.len(),
+            positions.cast::<f32>(),
+            vertices.vertex_count,
+            vertices.vertex_stride,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            vertex_lock.as_ptr().cast(),
+            target_count,
+            target_error,
+            options.bits(),
+            std::ptr::null_mut(),
+        )
+    };
+    result.resize(index_count, 0u32);
+    result
+}
+
+/// Reduces the number of triangles in the mesh, attempting to preserve mesh
+/// appearance as much as possible, while respecting the given vertex locks
+///
+/// The resulting index buffer references vertices from the original vertex buffer.
+///
+/// If the original vertex data isn't required, creating a compact vertex buffer
+/// using `optimize_vertex_fetch` is recommended.
+pub fn simplify_with_locks_decoder<T: DecodePosition>(
+    indices: &[u32],
+    vertices: &[T],
+    vertex_lock: &[bool],
+    target_count: usize,
+    target_error: f32,
+    options: SimplifyOptions,
+) -> Vec<u32> {
+    let positions = vertices
+        .iter()
+        .map(|vertex| vertex.decode_position())
+        .collect::<Vec<[f32; 3]>>();
+    let mut result: Vec<u32> = vec![0; indices.len()];
+    let index_count = unsafe {
+        ffi::meshopt_simplifyWithAttributes(
+            result.as_mut_ptr().cast(),
+            indices.as_ptr().cast(),
+            indices.len(),
+            positions.as_ptr().cast(),
+            positions.len(),
+            mem::size_of::<f32>() * 3,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            vertex_lock.as_ptr().cast(),
+            target_count,
+            target_error,
+            options.bits(),
+            std::ptr::null_mut(),
+        )
+    };
+    result.resize(index_count, 0u32);
+    result
+}
+
 /// Reduces the number of triangles in the mesh, sacrificing mesh appearance for simplification performance.
 /// The algorithm doesn't preserve mesh topology but is always able to reach target triangle count.
 ///


### PR DESCRIPTION
My vertex lock PR finally landed: https://github.com/zeux/meshoptimizer/pull/601

This PR updates the meshoptimizer to latest to incorporate that change, and adds an API to specifify which vertices to lock when simplifying.

A note for people previously using our Traverse branch for this feature, the API has changed somewhat; it now requires a slice of booleans specifying whether a vertex is locked for each vertex, rather than a slice of vertex indices.