### PR TITLE
Version bump to 0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meshopt"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Graham Wihlidal <graham@wihlidal.ca>"]
 description = "Rust ffi bindings and idiomatic wrapper for mesh optimizer"
 homepage = "https://github.com/gwihlidal/meshopt-rs"


### PR DESCRIPTION
This PR bumps the version to 0.2.1, to publish a new version that includes the vertex lock feature.