### PR TITLE
Improve support for cluster simplification

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 0.2.2 (2024-06-17)
+
+* Updated dependencies
+* Added `SimplifyOptions::Sparse` and `SimplifyOptions::ErrorAbsolute` options
+* Improved `build_meshlets` to automatically optimize meshlet triangle order for HW efficiency
+
 ## 0.2.1 (2024-04-03)
 
 * Updated dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meshopt"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Graham Wihlidal <graham@wihlidal.ca>"]
 description = "Rust ffi bindings and idiomatic wrapper for mesh optimizer"
 homepage = "https://github.com/gwihlidal/meshopt-rs"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-meshopt = "0.2.1"
+meshopt = "0.2.2"
 ```
 
 ## Example

--- a/src/simplify.rs
+++ b/src/simplify.rs
@@ -11,6 +11,11 @@ bitflags! {
         /// This can be valuable to simplify independent chunks of a mesh, for example terrain,
         /// to ensure that individual levels of detail can be stitched together later without gaps.
         const LockBorder = 1;
+        /// Improve simplification performance assuming input indices are a sparse subset of the mesh.
+        /// Note that error becomes relative to subset extents.
+        const Sparse = 2;
+        /// Treat error limit and resulting error as absolute instead of relative to mesh extents.
+        const ErrorAbsolute = 4;
     }
 }
 


### PR DESCRIPTION
This PR is meant to reflect additions made in https://github.com/zeux/meshoptimizer/pull/704: two extra flags provided are helpful to reduce the cost of running the simplification on small mesh subsets which you need to do for something like Nanite. This consistently comes up in these use cases so that should be helpful.

I've also changed `build_meshlets` to call `meshopt_optimizeMeshlet` on each meshlet automatically; I initially wanted to expose `meshopt_optimizeMeshlet` as a separate function to keep the interfaces of Rust and C++ version aligned, but because Meshlet carries immutable slices it wasn't clear how to make an API ergonomic; the big reason why this function is separate is that C++ library provides two different meshlet builders but Rust only exposes the better one, so it probably makes sense to keep Rust interface more streamlined. If we need control here in the future we could add (as a breaking change?) an options enum that allows to opt out of this.

I've tested this in Bevy with the following diff using the newly added meshlet example and work-in-progress meshlet processor PR. Note that without any diffs the code will still work just fine but will call optimizeMeshlet twice (which is a small extra cost); the minimal change would be to just remove that, but the newly added flags significantly reduce the simplification cost during mesh processing without changing the results.

<details>
<summary>bevy patch</summary>

```diff
diff --git a/crates/bevy_pbr/src/meshlet/from_mesh.rs b/crates/bevy_pbr/src/meshlet/from_mesh.rs
index a5ff00fad..64db1f226 100644
--- a/crates/bevy_pbr/src/meshlet/from_mesh.rs
+++ b/crates/bevy_pbr/src/meshlet/from_mesh.rs
@@ -6,9 +6,8 @@ use bevy_render::{
 use bevy_utils::{HashMap, HashSet};
 use itertools::Itertools;
 use meshopt::{
-    build_meshlets, compute_cluster_bounds, compute_meshlet_bounds,
-    ffi::{meshopt_Bounds, meshopt_optimizeMeshlet},
-    simplify, simplify_scale, Meshlets, SimplifyOptions, VertexDataAdapter,
+    build_meshlets, compute_cluster_bounds, compute_meshlet_bounds, ffi::meshopt_Bounds, simplify,
+    simplify_scale, Meshlets, SimplifyOptions, VertexDataAdapter,
 };
 use metis::Graph;
 use std::{borrow::Cow, ops::Range};
@@ -58,6 +57,8 @@ impl MeshletMesh {
             .map(|m| m.triangle_count as u64)
             .sum();

+        let scale = simplify_scale(&vertices);
+
         // Build further LODs
         let mut simplification_queue = 0..meshlets.len();
         let mut lod_level = 1;
@@ -82,7 +83,7 @@ impl MeshletMesh {
             for group_meshlets in groups.values().filter(|group| group.len() > 1) {
                 // Simplify the group to ~50% triangle count
                 let Some((simplified_group_indices, mut group_error)) =
-                    simplify_meshlet_groups(group_meshlets, &meshlets, &vertices, lod_level)
+                    simplify_meshlet_groups(group_meshlets, &meshlets, &vertices, lod_level, scale)
                 else {
                     continue;
                 };
@@ -179,22 +180,7 @@ fn validate_input_mesh(mesh: &Mesh) -> Result<Cow<'_, [u32]>, MeshToMeshletMeshC
 }

 fn compute_meshlets(indices: &[u32], vertices: &VertexDataAdapter) -> Meshlets {
-    let mut meshlets = build_meshlets(indices, vertices, 64, 64, 0.0);
-
-    for meshlet in &mut meshlets.meshlets {
-        #[allow(unsafe_code)]
-        #[allow(clippy::undocumented_unsafe_blocks)]
-        unsafe {
-            meshopt_optimizeMeshlet(
-                &mut meshlets.vertices[meshlet.vertex_offset as usize],
-                &mut meshlets.triangles[meshlet.triangle_offset as usize],
-                meshlet.triangle_count as usize,
-                meshlet.vertex_count as usize,
-            );
-        }
-    }
-
-    meshlets
+    build_meshlets(indices, vertices, 64, 64, 0.0)
 }
 
 fn collect_triangle_edges_per_meshlet(
@@ -287,6 +273,7 @@ fn simplify_meshlet_groups(
     meshlets: &Meshlets,
     vertices: &VertexDataAdapter<'_>,
     lod_level: u32,
+    scale: f32,
 ) -> Option<(Vec<u32>, f32)> {
     // Build a new index buffer into the mesh vertex data by combining all meshlet data in the group
     let mut group_indices = Vec::new();
@@ -299,7 +286,8 @@ fn simplify_meshlet_groups(

     // Allow more deformation for high LOD levels (1% at LOD 1, 10% at LOD 20+)
     let t = (lod_level - 1) as f32 / 19.0;
-    let target_error = 0.1 * t + 0.01 * (1.0 - t);
+    let target_error_rel = 0.1 * t + 0.01 * (1.0 - t);
+    let target_error = target_error_rel * scale;

     // Simplify the group to ~50% triangle count
     // TODO: Use simplify_with_locks()
@@ -309,7 +297,7 @@ fn simplify_meshlet_groups(
         vertices,
         group_indices.len() / 2,
         target_error,
-        SimplifyOptions::LockBorder,
+        SimplifyOptions::LockBorder | SimplifyOptions::Sparse | SimplifyOptions::ErrorAbsolute,
         Some(&mut error),
     );

@@ -318,9 +306,6 @@ fn simplify_meshlet_groups(
         return None;
     }

-    // Convert error to object-space and convert from diameter to radius
-    error *= simplify_scale(vertices) * 0.5;
-
     Some((simplified_group_indices, error))
 }
```
</summary>