### PR TITLE
add result_error to simplify_with_locks

### DIFF
--- a/src/simplify.rs
+++ b/src/simplify.rs
@@ -108,6 +108,7 @@ pub fn simplify_with_locks(
     target_count: usize,
     target_error: f32,
     options: SimplifyOptions,
+    result_error: Option<&mut f32>,
 ) -> Vec<u32> {
     let vertex_data = vertices.reader.get_ref();
     let vertex_data = vertex_data.as_ptr().cast::<u8>();
@@ -129,7 +130,7 @@ pub fn simplify_with_locks(
             target_count,
             target_error,
             options.bits(),
-            std::ptr::null_mut(),
+            result_error.map_or_else(std::ptr::null_mut, |v| v as *mut _),
         )
     };
     result.resize(index_count, 0u32);
@@ -150,6 +151,7 @@ pub fn simplify_with_locks_decoder<T: DecodePosition>(
     target_count: usize,
     target_error: f32,
     options: SimplifyOptions,
+    result_error: Option<&mut f32>,
 ) -> Vec<u32> {
     let positions = vertices
         .iter()
@@ -172,7 +174,7 @@ pub fn simplify_with_locks_decoder<T: DecodePosition>(
             target_count,
             target_error,
             options.bits(),
-            std::ptr::null_mut(),
+            result_error.map_or_else(std::ptr::null_mut, |v| v as *mut _),
         )
     };
     result.resize(index_count, 0u32);


### PR DESCRIPTION
The normal `simplify` functions take in `result_error` as a parameter, but `simplify_with_locks` doesn't, which I've added.