### PR TITLE
Remove use of `cargo-clippy` implicit feature.

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,6 +1,6 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::unreadable_literal))]
+#![allow(clippy::unreadable_literal)]
 
 include!("../gen/bindings.rs");


### PR DESCRIPTION
This hasn't been needed in a very long time (and the other clippy configurations within this crate haven't been checking it). It is also officially deprecated with 1.78 and later.