### PR TITLE
Remaining clippy fixes

### DIFF
--- a/src/clusterize.rs
+++ b/src/clusterize.rs
@@ -85,8 +85,7 @@ pub fn build_meshlets(
     };
     meshlets.truncate(count);
 
-    for i in 0..count {
-        let meshlet = &mut meshlets[i];
+    for meshlet in meshlets.iter_mut().take(count) {
         unsafe {
             ffi::meshopt_optimizeMeshlet(
                 &mut meshlet_verts[meshlet.vertex_offset as usize],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,6 @@
     clippy::match_wild_err_arm,
     clippy::match_wildcard_for_single_variants,
     clippy::mem_forget,
-    clippy::mismatched_target_os,
     clippy::missing_enforced_import_renames,
     clippy::mut_mut,
     clippy::mutex_integer,

--- a/src/packing.rs
+++ b/src/packing.rs
@@ -87,6 +87,7 @@ impl FromVertex for PackedVertexOct {
 #[derive(Default, Debug, Copy, Clone, PartialOrd)]
 #[repr(C)]
 /// A basic Vertex type that can be used with most mesh processing functions.
+///
 /// You don't _need_ to use this type, you can use your own type by implementing
 /// the `DecodePosition` trait and making a [`VertexDataAdapter`] from slices of it.
 ///

--- a/src/shadow.rs
+++ b/src/shadow.rs
@@ -1,7 +1,9 @@
 use crate::{ffi, DecodePosition, VertexDataAdapter, VertexStream};
 
 /// Generate index buffer that can be used for more efficient rendering when only a subset of the vertex
-/// attributes is necessary. All vertices that are binary equivalent (wrt first `vertex_size` bytes) map to
+/// attributes is necessary.
+///
+/// All vertices that are binary equivalent (wrt first `vertex_size` bytes) map to
 /// the first vertex in the original vertex buffer.
 ///
 /// This makes it possible to use the index buffer for Z pre-pass or shadowmap rendering, while using
@@ -26,7 +28,9 @@ pub fn generate_shadow_indices(indices: &[u32], vertices: &VertexDataAdapter<'_>
 }
 
 /// Generate index buffer that can be used for more efficient rendering when only a subset of the vertex
-/// attributes is necessary. All vertices that are binary equivalent (wrt first `vertex_size` bytes) map to
+/// attributes is necessary.
+///
+/// All vertices that are binary equivalent (wrt first `vertex_size` bytes) map to
 /// the first vertex in the original vertex buffer.
 ///
 /// This makes it possible to use the index buffer for Z pre-pass or shadowmap rendering, while using
@@ -56,7 +60,9 @@ pub fn generate_shadow_indices_decoder<T: DecodePosition>(
 }
 
 /// Generate index buffer that can be used for more efficient rendering when only a subset of the vertex
-/// attributes is necessary. All vertices that are binary equivalent (wrt specified streams) map to the
+/// attributes is necessary.
+///
+/// All vertices that are binary equivalent (wrt specified streams) map to the
 /// first vertex in the original vertex buffer.
 ///
 /// This makes it possible to use the index buffer for Z pre-pass or shadowmap rendering, while using

--- a/src/simplify.rs
+++ b/src/simplify.rs
@@ -182,6 +182,7 @@ pub fn simplify_with_locks_decoder<T: DecodePosition>(
 }
 
 /// Reduces the number of triangles in the mesh, sacrificing mesh appearance for simplification performance.
+///
 /// The algorithm doesn't preserve mesh topology but is always able to reach target triangle count.
 ///
 /// The resulting index buffer references vertices from the original vertex buffer.
@@ -217,6 +218,7 @@ pub fn simplify_sloppy(
 }
 
 /// Reduces the number of triangles in the mesh, sacrificing mesh appearance for simplification performance.
+///
 /// The algorithm doesn't preserve mesh topology but is always able to reach target triangle count.
 ///
 /// The resulting index buffer references vertices from the original vertex buffer.

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -68,6 +68,7 @@ union FloatUInt {
 }
 
 /// Quantize a float into half-precision floating point value.
+///
 /// Generates +-inf for overflow, preserves NaN, flushes denormals to zero, rounds to nearest.
 /// Representable magnitude range: [6e-5; 65504].
 /// Maximum relative reconstruction error: 5e-4.
@@ -94,6 +95,7 @@ pub fn quantize_half(v: f32) -> u16 {
 }
 
 /// Quantize a float into a floating point value with a limited number of significant mantissa bits.
+///
 /// Generates +-inf for overflow, preserves NaN, flushes denormals to zero, rounds to nearest.
 /// Assumes N is in a valid mantissa precision range, which is 1..23
 #[inline(always)]

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -217,7 +217,7 @@ mod tests {
         ];
 
         let mut adapter = VertexDataAdapter::new(
-            typed_to_bytes(&*vertices),
+            typed_to_bytes(&vertices),
             std::mem::size_of::<Vertex>(),
             offset_of!(Vertex, p),
         )


### PR DESCRIPTION
This wraps up the remaining clippy warnings on both `stable` and `nightly`.