### PR TITLE
Truncate vertices and triangles when building meshlets

### DIFF
--- a/src/clusterize.rs
+++ b/src/clusterize.rs
@@ -83,6 +83,14 @@ pub fn build_meshlets(
             cone_weight,
         )
     };
+
+    let last_meshlet = meshlets[count - 1];
+    meshlet_verts
+        .truncate(last_meshlet.vertex_offset as usize + last_meshlet.vertex_count as usize);
+    meshlet_tris.truncate(
+        last_meshlet.triangle_offset as usize
+            + ((last_meshlet.triangle_count as usize * 3 + 3) & !3),
+    );
     meshlets.truncate(count);
 
     for meshlet in meshlets.iter_mut().take(count) {


### PR DESCRIPTION
This is recommended by the upstream documentation but I noticed that only the meshlets vector was truncated but not the vertices/triangles.

https://github.com/zeux/meshoptimizer?tab=readme-ov-file#mesh-shading 