### PR TITLE
Fix `clippy::needless_lifetimes` lint.

### DIFF
--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -192,7 +192,7 @@ impl<'a> VertexDataAdapter<'a> {
     }
 }
 
-impl<'a> Read for VertexDataAdapter<'a> {
+impl Read for VertexDataAdapter<'_> {
     fn read(&mut self, buf: &mut [u8]) -> std::result::Result<usize, std::io::Error> {
         self.reader.read(buf)
     }


### PR DESCRIPTION
This is new in Rust 1.83.