### PR TITLE
deps: Update to `thiserror` 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 float-cmp = "0.10"
-thiserror = "1.0"
+thiserror = "2.0"
 bitflags = "2.4"
 
 [build-dependencies]


### PR DESCRIPTION
The breaking changes don't seem to apply here: https://github.com/dtolnay/thiserror/releases/tag/2.0.0