### PR TITLE
Update to meshoptimizer 0.23, add build_meshlets_flex fn

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 0.5.0 (2025-04-??)
+
+* Upgraded meshoptimizer library to 0.23 (hash 3e9d1ff3135794f519f3237515277c8d9a3fd3f2)
+* Added `build_meshlets_flex` API function
+
 ## 0.4.1 (2024-12-22)
 
 * Truncate vertices and triangles when building meshlets
@@ -7,7 +12,7 @@
 ## 0.4.0 (2024-10-25)
 
 * Upgraded meshoptimizer library to 0.22 (hash 4affad044571506a5724c9a6f15424f43e86f731)
-* Added `simplify_with_attributes_and_locks` API functions
+* Added `simplify_with_attributes_and_locks` API function
 
 ## 0.3.0 (2024-06-26)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meshopt"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Graham Wihlidal <graham@wihlidal.ca>"]
 description = "Rust ffi bindings and idiomatic wrapper for mesh optimizer"
 homepage = "https://github.com/gwihlidal/meshopt-rs"
@@ -23,12 +23,15 @@ include = [
     "vendor/src/indexgenerator.cpp",
     "vendor/src/overdrawanalyzer.cpp",
     "vendor/src/overdrawoptimizer.cpp",
+    "vendor/src/partition.cpp",
+    "vendor/src/quantization.cpp",
     "vendor/src/simplifier.cpp",
     "vendor/src/spatialorder.cpp",
     "vendor/src/stripifier.cpp",
     "vendor/src/vcacheanalyzer.cpp",
     "vendor/src/vcacheoptimizer.cpp",
     "vendor/src/vertexcodec.cpp",
+    "vendor/src/vertexfilter.cpp",
     "vendor/src/vfetchanalyzer.cpp",
     "vendor/src/vfetchoptimizer.cpp",
     "include_wasm32/*.h",

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-meshopt = "0.4.1"
+meshopt = "0.5"
 ```
 
 ## Example


### PR DESCRIPTION
Closes https://github.com/gwihlidal/meshopt-rs/issues/63.

I added `build_meshlets_flex `, but wasn't sure how to do `meshopt_computeSphereBounds` or `meshopt_partitionClusters ` (the other two functions I wanted). I'd appreciate it if you could implement those after this PR, before cutting a new release.