### PR TITLE
 Fix memory safety issues with VertexDataAdapter

### DIFF
--- a/src/clusterize.rs
+++ b/src/clusterize.rs
@@ -402,8 +402,11 @@ pub fn compute_sphere_bounds(
 ) -> Sphere {
     if let Some(ref r) = radius {
         assert_eq!(positions.position_count, r.radius_count);
+        assert!(r.data.len() >= r.radius_count * r.radius_stride);
+        assert!(r.radius_offset + mem::size_of::<f32>() <= r.radius_stride);
     }
     assert!(positions.data.len() >= positions.position_count * positions.position_stride);
+    assert!(positions.position_offset + mem::size_of::<f32>() * 3 <= positions.position_stride);
     unsafe {
         let (radius_ptr, radius_stride) = match radius {
             Some(r) => (r.data.as_ptr().add(r.radius_offset).cast(), r.radius_stride),

--- a/src/clusterize.rs
+++ b/src/clusterize.rs
@@ -1,5 +1,6 @@
 use crate::ffi;
 use crate::{DecodePosition, VertexDataAdapter};
+use std::mem;
 
 pub type Bounds = ffi::meshopt_Bounds;
 
@@ -144,8 +145,7 @@ pub fn build_meshlets_flex(
 ) -> Meshlets {
     let meshlet_count =
         unsafe { ffi::meshopt_buildMeshletsBound(indices.len(), max_vertices, min_triangles) };
-    let mut meshlets: Vec<ffi::meshopt_Meshlet> =
-        vec![unsafe { ::std::mem::zeroed() }; meshlet_count];
+    let mut meshlets: Vec<ffi::meshopt_Meshlet> = vec![unsafe { mem::zeroed() }; meshlet_count];
 
     let mut meshlet_verts: Vec<u32> = vec![0; meshlet_count * max_vertices];
     let mut meshlet_tris: Vec<u8> = vec![0; meshlet_count * max_triangles * 3];
@@ -188,8 +188,7 @@ pub fn build_meshlets_spatial(
 ) -> Meshlets {
     let meshlet_count =
         unsafe { ffi::meshopt_buildMeshletsBound(indices.len(), max_vertices, min_triangles) };
-    let mut meshlets: Vec<ffi::meshopt_Meshlet> =
-        vec![unsafe { ::std::mem::zeroed() }; meshlet_count];
+    let mut meshlets: Vec<ffi::meshopt_Meshlet> = vec![unsafe { mem::zeroed() }; meshlet_count];
 
     let mut meshlet_verts: Vec<u32> = vec![0; meshlet_count * max_vertices];
     let mut meshlet_tris: Vec<u8> = vec![0; meshlet_count * max_triangles * 3];
@@ -327,7 +326,7 @@ pub fn partition_clusters_with_decoder<T: DecodePosition>(
             cluster_index_counts.len(),
             positions.as_ptr().cast(),
             positions.len(),
-            std::mem::size_of::<f32>() * 3,
+            mem::size_of::<f32>() * 3,
             target_partition_size,
         )
     }
@@ -461,7 +460,7 @@ pub fn compute_cluster_bounds_decoder<T: DecodePosition>(
             indices.len(),
             vertices.as_ptr().cast(),
             vertices.len() * 3,
-            ::std::mem::size_of::<f32>() * 3,
+            mem::size_of::<f32>() * 3,
         )
     }
 }
@@ -494,7 +493,7 @@ pub fn compute_meshlet_bounds_decoder<T: DecodePosition>(
             meshlet.triangles.len() / 3,
             vertices.as_ptr().cast(),
             vertices.len() * 3,
-            std::mem::size_of::<f32>() * 3,
+            mem::size_of::<f32>() * 3,
         )
     }
 }
@@ -516,7 +515,7 @@ mod tests {
             PositionDataAdapter {
                 data: typed_to_bytes(vbr),
                 position_count: 4,
-                position_stride: 4 * ::std::mem::size_of::<f32>(),
+                position_stride: 4 * mem::size_of::<f32>(),
                 position_offset: 0,
             },
             None,
@@ -530,13 +529,13 @@ mod tests {
             PositionDataAdapter {
                 data: typed_to_bytes(vbr),
                 position_count: 4,
-                position_stride: 4 * ::std::mem::size_of::<f32>(),
+                position_stride: 4 * mem::size_of::<f32>(),
                 position_offset: 0,
             },
             Some(RadiusDataAdapter {
                 data: typed_to_bytes(eps),
                 radius_count: 4,
-                radius_stride: ::std::mem::size_of::<f32>(),
+                radius_stride: mem::size_of::<f32>(),
                 radius_offset: 0,
             }),
         );
@@ -550,14 +549,14 @@ mod tests {
             PositionDataAdapter {
                 data: typed_to_bytes(vbr),
                 position_count: 4,
-                position_stride: 4 * ::std::mem::size_of::<f32>(),
+                position_stride: 4 * mem::size_of::<f32>(),
                 position_offset: 0,
             },
             Some(RadiusDataAdapter {
                 data: typed_to_bytes(vbr),
                 radius_count: 4,
-                radius_stride: 4 * ::std::mem::size_of::<f32>(),
-                radius_offset: 3 * ::std::mem::size_of::<f32>(),
+                radius_stride: 4 * mem::size_of::<f32>(),
+                radius_offset: 3 * mem::size_of::<f32>(),
             }),
         );
 
@@ -656,8 +655,7 @@ mod tests {
         ];
 
         let vertex_adapter =
-            VertexDataAdapter::new(typed_to_bytes(vertices), 3 * std::mem::size_of::<f32>(), 0)
-                .unwrap();
+            VertexDataAdapter::new(typed_to_bytes(vertices), 3 * mem::size_of::<f32>(), 0).unwrap();
 
         // Test with positions - should produce better spatial partitioning
         let result = partition_clusters_with_positions(
@@ -766,7 +764,7 @@ mod tests {
         ];
 
         let vertices =
-            VertexDataAdapter::new(typed_to_bytes(vb), std::mem::size_of::<[f32; 3]>(), 0).unwrap();
+            VertexDataAdapter::new(typed_to_bytes(vb), mem::size_of::<[f32; 3]>(), 0).unwrap();
 
         // Up to 2 meshlets with min_triangles = 4
         assert_eq!(
@@ -817,7 +815,7 @@ mod tests {
         ];
 
         let vertices =
-            VertexDataAdapter::new(typed_to_bytes(vb), 3 * std::mem::size_of::<f32>(), 0).unwrap();
+            VertexDataAdapter::new(typed_to_bytes(vb), 3 * mem::size_of::<f32>(), 0).unwrap();
 
         // Up to 2 meshlets with min_triangles=4
         assert_eq!(

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -161,15 +161,12 @@ pub fn optimize_overdraw_in_place(
     vertices: &VertexDataAdapter<'_>,
     threshold: f32,
 ) {
-    let vertex_data = vertices.reader.get_ref();
-    let vertex_data = vertex_data.as_ptr().cast::<u8>();
-    let positions = unsafe { vertex_data.add(vertices.position_offset) };
     unsafe {
         ffi::meshopt_optimizeOverdraw(
             indices.as_mut_ptr(),
             indices.as_ptr(),
             indices.len(),
-            positions.cast(),
+            vertices.pos_ptr(),
             vertices.vertex_count,
             vertices.vertex_stride,
             threshold,

--- a/src/simplify.rs
+++ b/src/simplify.rs
@@ -42,16 +42,13 @@ pub fn simplify(
     options: SimplifyOptions,
     result_error: Option<&mut f32>,
 ) -> Vec<u32> {
-    let vertex_data = vertices.reader.get_ref();
-    let vertex_data = vertex_data.as_ptr().cast::<u8>();
-    let positions = unsafe { vertex_data.add(vertices.position_offset) };
     let mut result: Vec<u32> = vec![0; indices.len()];
     let index_count = unsafe {
         ffi::meshopt_simplify(
             result.as_mut_ptr().cast(),
             indices.as_ptr().cast(),
             indices.len(),
-            positions.cast::<f32>(),
+            vertices.pos_ptr(),
             vertices.vertex_count,
             vertices.vertex_stride,
             target_count,
@@ -118,16 +115,13 @@ pub fn simplify_with_locks(
     options: SimplifyOptions,
     result_error: Option<&mut f32>,
 ) -> Vec<u32> {
-    let vertex_data = vertices.reader.get_ref();
-    let vertex_data = vertex_data.as_ptr().cast::<u8>();
-    let positions = unsafe { vertex_data.add(vertices.position_offset) };
     let mut result: Vec<u32> = vec![0; indices.len()];
     let index_count = unsafe {
         ffi::meshopt_simplifyWithAttributes(
             result.as_mut_ptr().cast(),
             indices.as_ptr().cast(),
             indices.len(),
-            positions.cast::<f32>(),
+            vertices.pos_ptr(),
             vertices.vertex_count,
             vertices.vertex_stride,
             std::ptr::null(),
@@ -210,16 +204,13 @@ pub fn simplify_with_attributes_and_locks(
     options: SimplifyOptions,
     result_error: Option<&mut f32>,
 ) -> Vec<u32> {
-    let vertex_data = vertices.reader.get_ref();
-    let vertex_data = vertex_data.as_ptr().cast::<u8>();
-    let positions = unsafe { vertex_data.add(vertices.position_offset) };
     let mut result: Vec<u32> = vec![0; indices.len()];
     let index_count = unsafe {
         ffi::meshopt_simplifyWithAttributes(
             result.as_mut_ptr().cast(),
             indices.as_ptr().cast(),
             indices.len(),
-            positions.cast::<f32>(),
+            vertices.pos_ptr(),
             vertices.vertex_count,
             vertices.vertex_stride,
             vertex_attributes.as_ptr(),
@@ -301,16 +292,13 @@ pub fn simplify_sloppy(
     target_error: f32,
     result_error: Option<&mut f32>,
 ) -> Vec<u32> {
-    let vertex_data = vertices.reader.get_ref();
-    let vertex_data = vertex_data.as_ptr().cast::<u8>();
-    let positions = unsafe { vertex_data.add(vertices.position_offset) };
     let mut result: Vec<u32> = vec![0; indices.len()];
     let index_count = unsafe {
         ffi::meshopt_simplifySloppy(
             result.as_mut_ptr().cast(),
             indices.as_ptr().cast(),
             indices.len(),
-            positions.cast(),
+            vertices.pos_ptr(),
             vertices.vertex_count,
             vertices.vertex_stride,
             std::ptr::null(),
@@ -378,9 +366,7 @@ pub fn simplify_sloppy_with_locks(
     target_error: f32,
     result_error: Option<&mut f32>,
 ) -> Vec<u32> {
-    let vertex_data = vertices.reader.get_ref();
-    let vertex_data = vertex_data.as_ptr().cast::<u8>();
-    let positions = unsafe { vertex_data.add(vertices.position_offset) };
+    let positions = vertices.pos_ptr();
     let mut result: Vec<u32> = vec![0; indices.len()];
     let index_count = unsafe {
         ffi::meshopt_simplifySloppy(

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -1,5 +1,6 @@
 use crate::{Error, Result};
 use std::io::{Cursor, Read};
+use std::mem;
 
 #[inline(always)]
 pub fn any_as_u8_slice<T: Sized>(p: &T) -> &[u8] {
@@ -204,6 +205,8 @@ impl<'a> VertexDataAdapter<'a> {
     pub fn pos_ptr(&self) -> *const f32 {
         let vertex_data = self.reader.get_ref();
         let vertex_data = vertex_data.as_ptr().cast::<u8>();
+        // safety: position_offset must point to 3xf32 bytes within each vertex
+        assert!(self.position_offset + mem::size_of::<f32>() * 3 <= self.vertex_stride);
         let positions = unsafe { vertex_data.add(self.position_offset) };
         positions.cast()
     }


### PR DESCRIPTION
Instead of using manual address math in some places, consistently use
vertices.pos_ptr(). This allows us to assert that position_offset is in
range in one place, which fixes memory safety concerns with VDA APIs.

Fixes #65.